### PR TITLE
simplify designer startup

### DIFF
--- a/dist/designer/xoom
+++ b/dist/designer/xoom
@@ -1,3 +1,3 @@
 #!/bin/bash
-export VLINGO_XOOM_STARTER_HOME="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-java -jar $VLINGO_XOOM_STARTER_HOME/bin/vlingo-xoom-starter-dist.jar $@ --currentDirectory ${PWD}
+export VLINGO_XOOM_DESIGNER_HOME="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+java -jar $VLINGO_XOOM_DESIGNER_HOME/bin/vlingo-xoom-starter-dist.jar $@ --currentDirectory ${PWD}

--- a/dist/designer/xoom
+++ b/dist/designer/xoom
@@ -1,3 +1,3 @@
 #!/bin/bash
 export VLINGO_XOOM_DESIGNER_HOME="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-java -jar $VLINGO_XOOM_DESIGNER_HOME/bin/vlingo-xoom-starter-dist.jar $@ --currentDirectory ${PWD}
+java -jar $VLINGO_XOOM_DESIGNER_HOME/bin/xoom-designer-dist.jar $@ --currentDirectory ${PWD}

--- a/dist/designer/xoom
+++ b/dist/designer/xoom
@@ -1,3 +1,3 @@
 #!/bin/bash
-export VLINGO_XOOM_DESIGNER_HOME="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+export VLINGO_XOOM_DESIGNER_HOME=${VLINGO_XOOM_DESIGNER_HOME:-"$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"}
 java -jar $VLINGO_XOOM_DESIGNER_HOME/bin/xoom-designer-dist.jar $@ --currentDirectory ${PWD}

--- a/dist/designer/xoom
+++ b/dist/designer/xoom
@@ -1,2 +1,3 @@
 #!/bin/bash
-java -jar $VLINGO_XOOM_DESIGNER_HOME/bin/xoom-designer-dist.jar $@ --currentDirectory ${PWD}
+export VLINGO_XOOM_STARTER_HOME="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+java -jar $VLINGO_XOOM_STARTER_HOME/bin/vlingo-xoom-starter-dist.jar $@ --currentDirectory ${PWD}

--- a/dist/designer/xoom.bat
+++ b/dist/designer/xoom.bat
@@ -1,5 +1,5 @@
 @ECHO OFF
-set VLINGO_XOOM_DESIGNER_HOME=%~dp0
+if "%VLINGO_XOOM_DESIGNER_HOME%"=="" set VLINGO_XOOM_DESIGNER_HOME=%~dp0
 set directoryArg=--currentDirectory
 set args=%* %directoryArg% %CD%
 call java -jar %VLINGO_XOOM_DESIGNER_HOME%\bin\xoom-designer-dist.jar %args%

--- a/dist/designer/xoom.bat
+++ b/dist/designer/xoom.bat
@@ -2,4 +2,4 @@
 set VLINGO_XOOM_DESIGNER_HOME=%~dp0
 set directoryArg=--currentDirectory
 set args=%* %directoryArg% %CD%
-call java -jar %VLINGO_XOOM_DESIGNER_HOME%\bin\vlingo-xoom-starter-dist.jar %args%
+call java -jar %VLINGO_XOOM_DESIGNER_HOME%\bin\xoom-designer-dist.jar %args%

--- a/dist/designer/xoom.bat
+++ b/dist/designer/xoom.bat
@@ -1,4 +1,5 @@
 @ECHO OFF
-set "directoryArg=--currentDirectory"
+set VLINGO_XOOM_STARTER_HOME=%~dp0
+set directoryArg=--currentDirectory
 set args=%* %directoryArg% %CD%
-call java -jar %VLINGO_XOOM_DESIGNER_HOME%\bin\xoom-designer-dist.jar %args%
+call java -jar %VLINGO_XOOM_STARTER_HOME%\bin\vlingo-xoom-starter-dist.jar %args%

--- a/dist/designer/xoom.bat
+++ b/dist/designer/xoom.bat
@@ -1,5 +1,5 @@
 @ECHO OFF
-set VLINGO_XOOM_STARTER_HOME=%~dp0
+set VLINGO_XOOM_DESIGNER_HOME=%~dp0
 set directoryArg=--currentDirectory
 set args=%* %directoryArg% %CD%
-call java -jar %VLINGO_XOOM_STARTER_HOME%\bin\vlingo-xoom-starter-dist.jar %args%
+call java -jar %VLINGO_XOOM_DESIGNER_HOME%\bin\vlingo-xoom-starter-dist.jar %args%


### PR DESCRIPTION
## Problem

XOOM designer doesn't open on either OSX or Windows out of the box, leading to first-time user frustration

## Solution

- eliminate the need to set variables manually

## Current Problems

- OSX works now (apart from not finding `vlingo-cluster.properties`), but on Windows the script simply stops without any feedback

osx: 

```text
% ./xoom gui
=========================
service: xoom-starter.
=========================
Unable to find vlingo-cluster.properties. Using default grid cluster settings.
WARNING: Missing file: src/main/resources/vlingo-cluster.properties -- create or use ClusterProperties.
WARNING: An illegal reflective access operation has occurred
...
Done!
```

windows:

```text
>xoom gui
=========================
service: xoom-starter.
=========================
Unable to find vlingo-cluster.properties. Using default grid cluster settings.
WARNING: Missing file: src/main/resources/vlingo-cluster.properties -- create or use ClusterProperties.
>
```