### PR TITLE
Fix reactjs codegen method names

### DIFF
--- a/src/main/resources/codegen/reactjs/AggregateDetail.ftl
+++ b/src/main/resources/codegen/reactjs/AggregateDetail.ftl
@@ -50,7 +50,7 @@ const ${fns.capitalize(aggregate.aggregateName)} = () => {
 
   <#list aggregate.methods as method>
     <#if !method.useFactory >
-  const ${method.name} = useCallback((e) => {
+  const _${method.name} = useCallback((e) => {
     console.log('showing ${method.name} modal');
     const form = {
       id: item.id,
@@ -80,7 +80,7 @@ const ${fns.capitalize(aggregate.aggregateName)} = () => {
           <div className="btn-group me-2">
             <#list aggregate.methods as method>
               <#if !method.useFactory >
-            <button type="button" className="btn btn-sm btn-outline-secondary" onClick={${method.name}}>${fns.capitalize(method.name)}</button>
+            <button type="button" className="btn btn-sm btn-outline-secondary" onClick={_${method.name}}>${fns.capitalize(method.name)}</button>
               </#if>
             </#list>
           </div>

--- a/src/main/resources/codegen/reactjs/AggregateList.ftl
+++ b/src/main/resources/codegen/reactjs/AggregateList.ftl
@@ -58,7 +58,7 @@ const ${fns.capitalize(fns.makePlural(aggregate.aggregateName))} = () => {
     setCurrentModal(null);
   }, [loadItems]);
 
-  const ${creatorMethod.name} = useCallback((e) => {
+  const _${creatorMethod.name} = useCallback((e) => {
     console.log('showing ${creatorMethod.name} modal');
     setCurrentModal(<${aggregate.aggregateName}${fns.capitalize(creatorMethod.name)} defaultForm={EMPTY_FORM} complete={onModalActionComplete}/>);
   }, [onModalActionComplete]);
@@ -74,7 +74,7 @@ const ${fns.capitalize(fns.makePlural(aggregate.aggregateName))} = () => {
         <h1 className="h2">${fns.makePlural(aggregate.aggregateName)}</h1>
         <div className="btn-toolbar mb-2 mb-md-0">
           <div className="btn-group me-2">
-            <button type="button" className="btn btn-sm btn-outline-secondary" onClick={${creatorMethod.name}}>${fns.capitalize(creatorMethod.name)}</button>
+            <button type="button" className="btn btn-sm btn-outline-secondary" onClick={_${creatorMethod.name}}>${fns.capitalize(creatorMethod.name)}</button>
           </div>
         </div>
       </div>

--- a/src/test/java/io/vlingo/xoom/designer/task/projectgeneration/reactjs/AggregateDetailTest.java
+++ b/src/test/java/io/vlingo/xoom/designer/task/projectgeneration/reactjs/AggregateDetailTest.java
@@ -46,10 +46,10 @@ public class AggregateDetailTest extends BaseTemplateTest{
         assertTrue(result.contains("import PetRename from \"./PetRename\";"));
         assertTrue(result.contains("const Pet = () => {"));
         assertTrue(result.contains("axios.get('/pets/'+id)"));
-        assertTrue(result.contains("const rename = useCallback((e) => {"));
+        assertTrue(result.contains("const _rename = useCallback((e) => {"));
         assertTrue(result.contains("setCurrentModal(<PetRename "));
         assertTrue(result.contains("<h1 className=\"h2\">Pet</h1>"));
-        assertTrue(result.contains("<button type=\"button\" className=\"btn btn-sm btn-outline-secondary\" onClick={rename}>Rename</button>"));
+        assertTrue(result.contains("<button type=\"button\" className=\"btn btn-sm btn-outline-secondary\" onClick={_rename}>Rename</button>"));
         assertTrue(containsPattern(Pattern.compile("<tbody>\\s*<tr><td>Id</td><td>\\{item\\?\\.id}</td></tr>\\s*<tr><td>Name</td><td>\\{item\\?\\.name}</td></tr>\\s*</tbody>"), result));
         assertTrue(result.contains("export default Pet;"));
     }

--- a/src/test/java/io/vlingo/xoom/designer/task/projectgeneration/reactjs/AggregateListTest.java
+++ b/src/test/java/io/vlingo/xoom/designer/task/projectgeneration/reactjs/AggregateListTest.java
@@ -43,9 +43,9 @@ public class AggregateListTest extends BaseTemplateTest {
         assertTrue(result.contains("import PetRegister from \"./PetRegister\";"));
         assertTrue(result.contains("const EMPTY_FORM = { name: '' };"));
         assertTrue(result.contains("const Pets = () => {"));
-        assertTrue(containsPattern(Pattern.compile("<button type=\"button\" className=\"btn btn-sm btn-outline-secondary\" onClick=\\{register}>Register</button>"), result));
+        assertTrue(containsPattern(Pattern.compile("<button type=\"button\" className=\"btn btn-sm btn-outline-secondary\" onClick=\\{_register}>Register</button>"), result));
         assertTrue(result.contains("axios.get('/pets')"));
-        assertTrue(result.contains("const register = useCallback((e) => {"));
+        assertTrue(result.contains("const _register = useCallback((e) => {"));
         assertTrue(result.contains("setCurrentModal(<PetRegister "));
         assertTrue(result.contains("<h1 className=\"h2\">Pets</h1>"));
         assertTrue(containsPattern(Pattern.compile("<tr>\\s*<th>Id</th>\\s*<th>Name</th>\\s*</tr>"), result));
@@ -96,9 +96,9 @@ public class AggregateListTest extends BaseTemplateTest {
         assertTrue(result.contains("import CustomerRegister from \"./CustomerRegister\";"));
         assertTrue(result.contains("const EMPTY_FORM = { name: '', contact: { phone: '', address: '' } };"));
         assertTrue(result.contains("const Customers = () => {"));
-        assertTrue(containsPattern(Pattern.compile("<button type=\"button\" className=\"btn btn-sm btn-outline-secondary\" onClick=\\{register}>Register</button>"), result));
+        assertTrue(containsPattern(Pattern.compile("<button type=\"button\" className=\"btn btn-sm btn-outline-secondary\" onClick=\\{_register}>Register</button>"), result));
         assertTrue(result.contains("axios.get('/customers')"));
-        assertTrue(result.contains("const register = useCallback((e) => {"));
+        assertTrue(result.contains("const _register = useCallback((e) => {"));
         assertTrue(result.contains("setCurrentModal(<CustomerRegister "));
         assertTrue(result.contains("<h1 className=\"h2\">Customers</h1>"));
         assertTrue(containsPattern(Pattern.compile("<tr>\\s*<th>Id</th>\\s*<th>Name</th>\\s*<th>Contact Phone</th>\\s*<th>Contact Address</th>\\s*</tr>"), result));


### PR DESCRIPTION
Sometimes users can use keywords as the method names. If this happens, It would break generated project. We need to prevent this problem.